### PR TITLE
Upgrade to axum 0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-auth"
 description = "High-level http auth extractors for axum"
-version = "0.4.1"
+version = "0.5.0"
 readme = "README.md"
 repository = "https://github.com/owez/axum-auth"
 license = "MIT OR Apache-2.0"
@@ -14,12 +14,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1.73"
-axum-core = "0.3"
-base64 = "0.13"
-http = "0.2"
+axum = "0.7"
+axum-core = "0.4"
+base64 = "0.21"
+http = "1"
 
 [dev-dependencies]
-axum = "0.6"
+axum = "0.7"
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-auth"
 description = "High-level http auth extractors for axum"
-version = "0.5.0"
+version = "0.7.0"
 readme = "README.md"
 repository = "https://github.com/owez/axum-auth"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1.73"
-axum = "0.7"
 axum-core = "0.4"
 base64 = "0.21"
 http = "1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 High-level [http auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) extractors for [axum](https://github.com/tokio-rs/axum)
 
-🚨 This crate provides an alternative to `TypedHeader<Authorization<..>>` which you should probably [use](https://docs.rs/axum/latest/axum/struct.TypedHeader.html) instead. Take a look at the fantastic [axum-login](https://github.com/maxcountryman/axum-login) crate if your looking for more robust session management. I will continue to maintain this crate.
+🚨 This crate provides an alternative to `TypedHeader<Authorization<..>>` which you may [use](https://docs.rs/axum-extra/latest/axum_extra/struct.TypedHeader.html) instead. Take a look at the fantastic [axum-login](https://github.com/maxcountryman/axum-login) crate if your looking for more robust session management. I will continue to maintain this crate.
 
 ## Usage
 
@@ -36,19 +36,21 @@ You can also define custom extractors, letting you return custom extractors, sta
 
 ## Installation
 
-Simply place the following inside of your `Cargo.toml` file for axum 0.6:
+Simply place the following inside of your `Cargo.toml` file for axum:
 
 ```toml
 [dependencies]
-axum-auth = "0.4"
+axum-auth = "0.7"
 ```
 
-If you're still on axum 0.5, you can use the `0.3` version. You can also enable just basic/bearer auth via features. To enable just basic auth, you can add this to the `Cargo.toml` file instead:
+Our version follows axum since 0.7. You can also enable just basic/bearer auth via features. To enable just basic auth, you can add this to the `Cargo.toml` file instead:
 
 ```toml
 [dependencies]
-axum-auth = { version = "0.4", default-features = false, features = ["auth-basic"] }
+axum-auth = { version = "0.7", default-features = false, features = ["auth-basic"] }
 ```
+
+If you're still using axum 0.5, use version 0.3. If you're still using axum 0.6, use version 0.5.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our version follows axum since 0.7. You can also enable just basic/bearer auth v
 axum-auth = { version = "0.7", default-features = false, features = ["auth-basic"] }
 ```
 
-If you're still using axum 0.5, use version 0.3. If you're still using axum 0.6, use version 0.5.
+If you're still using axum 0.5, use version 0.3. If you're still using axum 0.6, use version 0.4.
 
 ## Security
 

--- a/src/auth_basic.rs
+++ b/src/auth_basic.rs
@@ -5,6 +5,7 @@
 use crate::{get_header, Rejection, ERR_DECODE, ERR_DEFAULT, ERR_WRONG_BASIC};
 use async_trait::async_trait;
 use axum_core::extract::FromRequestParts;
+use base64::Engine;
 use http::{request::Parts, StatusCode};
 
 /// Basic authentication extractor, containing an identifier as well as an optional password
@@ -167,7 +168,9 @@ pub trait AuthBasicCustom: Sized {
 /// Decodes the two parts of basic auth using the colon
 fn decode(input: &str, err: Rejection) -> Result<(String, Option<String>), Rejection> {
     // Decode from base64 into a string
-    let decoded = base64::decode(input).map_err(|_| err)?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .map_err(|_| err)?;
     let decoded = String::from_utf8(decoded).map_err(|_| err)?;
 
     // Return depending on if password is present

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use axum::{extract::FromRequestParts, routing::get, Router};
 use axum_auth::{AuthBasicCustom, AuthBearerCustom, Rejection};
 use http::{request::Parts, StatusCode};
+use tokio::net::TcpListener;
 use std::net::SocketAddr;
 
 struct MyCustomBasic((String, Option<String>));
@@ -59,10 +60,12 @@ async fn launcher() {
 
     // Launch
     let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    axum::serve(
+        TcpListener::bind(addr).await.unwrap(),
+        app.into_make_service(),
+    )
+    .await
+    .unwrap();
 
     async fn tester_basic(MyCustomBasic((id, password)): MyCustomBasic) -> String {
         format!("Got {} and {:?}", id, password)
@@ -92,7 +95,7 @@ async fn tester() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+    assert_eq!(resp.status().as_u16(), StatusCode::IM_A_TEAPOT.as_u16());
     assert_eq!(
         resp.text().await.unwrap(),
         String::from("`Authorization` header must be for basic authentication")
@@ -106,7 +109,7 @@ async fn tester() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+    assert_eq!(resp.status().as_u16(), StatusCode::IM_A_TEAPOT.as_u16());
     assert_eq!(
         resp.text().await.unwrap(),
         String::from("`Authorization` header must be a bearer token")


### PR DESCRIPTION
This PR upgrades the `axum`, `http` and `base64` crates.

At this moment, `reqwest` has not yet upgraded to http v1 yet, so I use `StatusCode::as_u16()` for status code tests.