### PR TITLE
support axum-0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axum-auth"
 description = "High-level http auth extractors for axum"
-version = "0.7.0"
+version = "0.8.0"
 readme = "README.md"
 repository = "https://github.com/owez/axum-auth"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait = "0.1.73"
-axum-core = "0.4"
+axum-core = "0.5"
 base64 = "0.21"
 http = "1"
 
 [dev-dependencies]
-axum = "0.7"
+axum = "0.8"
 reqwest = "0.11"
 tokio = { version = "1", features = ["full"] }
 

--- a/src/auth_basic.rs
+++ b/src/auth_basic.rs
@@ -3,7 +3,6 @@
 //! See [AuthBasic] for the most commonly-used data structure
 
 use crate::{get_header, Rejection, ERR_DECODE, ERR_DEFAULT, ERR_WRONG_BASIC};
-use async_trait::async_trait;
 use axum_core::extract::FromRequestParts;
 use base64::Engine;
 use http::{request::Parts, StatusCode};
@@ -40,7 +39,6 @@ use http::{request::Parts, StatusCode};
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AuthBasic(pub (String, Option<String>));
 
-#[async_trait]
 impl<B> FromRequestParts<B> for AuthBasic
 where
     B: Send + Sync,
@@ -83,7 +81,6 @@ impl AuthBasicCustom for AuthBasic {
 /// use axum_auth::{AuthBasicCustom, Rejection};
 /// use http::{request::Parts, StatusCode};
 /// use axum::extract::FromRequestParts;
-/// use async_trait::async_trait;
 ///
 /// /// Your custom basic auth returning a fun 418 for errors
 /// struct MyCustomBasicAuth((String, Option<String>));
@@ -99,7 +96,6 @@ impl AuthBasicCustom for AuthBasic {
 /// }
 ///
 /// // this is just boilerplate, copy-paste this
-/// #[async_trait]
 /// impl<B> FromRequestParts<B> for MyCustomBasicAuth
 /// where
 ///     B: Send + Sync,

--- a/src/auth_bearer.rs
+++ b/src/auth_bearer.rs
@@ -3,7 +3,6 @@
 //! See [AuthBearer] for the most commonly-used data structure
 
 use crate::{Rejection, ERR_CHARS, ERR_DEFAULT, ERR_MISSING, ERR_WRONG_BEARER};
-use async_trait::async_trait;
 use axum_core::extract::FromRequestParts;
 use http::{header::AUTHORIZATION, request::Parts, StatusCode};
 
@@ -34,7 +33,6 @@ use http::{header::AUTHORIZATION, request::Parts, StatusCode};
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AuthBearer(pub String);
 
-#[async_trait]
 impl<B> FromRequestParts<B> for AuthBearer
 where
     B: Send + Sync,
@@ -74,7 +72,6 @@ impl AuthBearerCustom for AuthBearer {
 /// This is what a typical custom extractor should look like in full, copy-paste this and edit it:
 ///
 /// ```rust
-/// use async_trait::async_trait;
 /// use axum::extract::FromRequestParts;
 /// use axum_auth::{AuthBearerCustom, Rejection};
 /// use http::{request::Parts, StatusCode};
@@ -93,7 +90,6 @@ impl AuthBearerCustom for AuthBearer {
 /// }
 ///
 /// // this is just boilerplate, copy-paste this
-/// #[async_trait]
 /// impl<B> FromRequestParts<B> for MyCustomBearerAuth
 /// where
 ///     B: Send + Sync,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) const ERR_WRONG_BASIC: &str = "`Authorization` header must be for bas
 /// The header was set as basic authentication when we're expecting bearer
 pub(crate) const ERR_WRONG_BEARER: &str = "`Authorization` header must be a bearer token";
 
+#[allow(dead_code)]
 /// Helper trait for decoding [Parts] to a final extractor; this is the main interface into the decoding system
 pub(crate) trait DecodeRequestParts: Sized {
     /// Decodes all provided [Parts] into a new instance of self, going through the entire decoding cycle

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use axum::{extract::FromRequestParts, routing::get, Router};
 use axum_auth::{AuthBasicCustom, AuthBearerCustom, Rejection};
 use http::{request::Parts, StatusCode};
@@ -16,7 +15,6 @@ impl AuthBasicCustom for MyCustomBasic {
     }
 }
 
-#[async_trait]
 impl<B> FromRequestParts<B> for MyCustomBasic
 where
     B: Send + Sync,
@@ -39,7 +37,6 @@ impl AuthBearerCustom for MyCustomBearer {
     }
 }
 
-#[async_trait]
 impl<B> FromRequestParts<B> for MyCustomBearer
 where
     B: Send + Sync,


### PR DESCRIPTION
Axum relased 0.8 version (see [here](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0) for details) and remove the need to use async-trait. This commit upgrades the dependencies and remove the unnecessary async-trait support. 